### PR TITLE
infrastructure: log message unifications

### DIFF
--- a/include/clog.h
+++ b/include/clog.h
@@ -211,13 +211,10 @@ class CLog
 
 			    	if(msCount.length() > 6) msCount = msCount.substr(msCount.length() - 6, 6);
 
-					fs << localtimeBuffer << "." << msCount << "[" << processID << "] " << (level ? SpellLogLevel(level) + ":" : "") << mess << endl;
-					// fprintf(fh, "%s", ost.str().c_str());
+					fs << localtimeBuffer << "." << msCount << "";
 			    }
-			    else
-			    {
-					fs << "[" << processID << "] " << (level ? SpellLogLevel(level) + ":" : "") << mess << endl;
-			    }
+
+				fs << "[" << processID << "] " << SpellLogLevel(level) << ": " << mess << endl;
 
 			    fs.close();
 			}

--- a/include/clog.h
+++ b/include/clog.h
@@ -214,6 +214,8 @@ class CLog
 					fs << localtimeBuffer << "." << msCount << "";
 			    }
 
+			    // --- do NOT change log format !!!
+			    // --- logmessages parsed by fluent-bit_app-log_parser with regular expression
 				fs << "[" << processID << "] " << SpellLogLevel(level) << ": " << mess << endl;
 
 			    fs.close();


### PR DESCRIPTION
- before commit DEBUG keyword ommited from log message to reduce log size
- after commit, logging severity keyword became mandatory part of every message
  this will help to fluent-bit parser to split log messages to JSON format